### PR TITLE
Rename events to listeners

### DIFF
--- a/src/main/java/net/savagellc/savagecore/SavageCore.java
+++ b/src/main/java/net/savagellc/savagecore/SavageCore.java
@@ -2,11 +2,11 @@ package net.savagellc.savagecore;
 
 import net.prosavage.baseplugin.BasePlugin;
 import net.savagellc.savagecore.commands.BaseCommand;
-import net.savagellc.savagecore.events.*;
-import net.savagellc.savagecore.events.autorespawn.AutoRespawnEvent;
-import net.savagellc.savagecore.events.factions.AntiWildernessSpawner;
-import net.savagellc.savagecore.events.mobs.FastIronGolemDeath;
-import net.savagellc.savagecore.events.player.BloodSprayEvent;
+import net.savagellc.savagecore.listener.*;
+import net.savagellc.savagecore.listener.autorespawn.AutoRespawnListener;
+import net.savagellc.savagecore.listener.factions.AntiWildernessSpawner;
+import net.savagellc.savagecore.listener.mobs.FastIronGolemDeath;
+import net.savagellc.savagecore.listener.player.BloodSprayListener;
 import net.savagellc.savagecore.persist.Conf;
 import net.savagellc.savagecore.utils.FileManager;
 import net.savagellc.savagecore.utils.FileManager.Files;
@@ -49,23 +49,23 @@ public final class SavageCore extends BasePlugin implements Listener {
     }
 
     private void loadLists() {
-        registerListeners(new DenyItemBurnEvent(),
-                new DenyIceMeltEvent(),
-                new DenyBabyMobEvent(),
-                new DenyWeatherEvent(),
-                new DenyEndermanEvent(),
-                new DenyFireSpreadEvent(),
+        registerListeners(new DenyItemBurnListener(),
+                new DenyIceMeltListener(),
+                new DenyBabyMobListener(),
+                new DenyWeatherListener(),
+                new DenyEndermanListener(),
+                new DenyFireSpreadListener(),
                 new DenyBlazeDrowning(),
                 new DenyWaterRedstone(),
-                new DenyIPPostEvent(),
+                new DenyIPPostListener(),
                 new DenySpawnerStorage(),
                 new DenySpawnerGuard(),
                 new FastIronGolemDeath(),
-                new FastIceBreakEvent(),
-                new AutoRespawnEvent(),
+                new FastIceBreakListener(),
+                new AutoRespawnListener(),
                 new AntiWildernessSpawner(),
-                new DenyPearlGlitchEvent(),
-                new BloodSprayEvent());
+                new DenyPearlGlitchListener(),
+                new BloodSprayListener());
 
     }
 }

--- a/src/main/java/net/savagellc/savagecore/listener/DenyBabyMobListener.java
+++ b/src/main/java/net/savagellc/savagecore/listener/DenyBabyMobListener.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events;
+package net.savagellc.savagecore.listener;
 
 import net.savagellc.savagecore.persist.Conf;
 import org.bukkit.entity.Zombie;
@@ -6,7 +6,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 
-public class DenyBabyMobEvent implements Listener {
+public class DenyBabyMobListener implements Listener {
     @EventHandler
     public void onZombieSpawn(CreatureSpawnEvent e) {
         if (Conf.babyMobToggle && e.getEntity() instanceof Zombie) {

--- a/src/main/java/net/savagellc/savagecore/listener/DenyBlazeDrowning.java
+++ b/src/main/java/net/savagellc/savagecore/listener/DenyBlazeDrowning.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events;
+package net.savagellc.savagecore.listener;
 
 import net.savagellc.savagecore.persist.Conf;
 import org.bukkit.entity.Blaze;

--- a/src/main/java/net/savagellc/savagecore/listener/DenyEndermanListener.java
+++ b/src/main/java/net/savagellc/savagecore/listener/DenyEndermanListener.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events;
+package net.savagellc.savagecore.listener;
 
 import com.massivecraft.factions.Board;
 import com.massivecraft.factions.FLocation;
@@ -12,7 +12,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.*;
 
-public class DenyEndermanEvent implements Listener {
+public class DenyEndermanListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onEntityChangeBlock(EntityChangeBlockEvent e) {

--- a/src/main/java/net/savagellc/savagecore/listener/DenyFireSpreadListener.java
+++ b/src/main/java/net/savagellc/savagecore/listener/DenyFireSpreadListener.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events;
+package net.savagellc.savagecore.listener;
 
 import net.savagellc.savagecore.persist.Conf;
 import org.bukkit.event.EventHandler;
@@ -7,7 +7,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockIgniteEvent;
 import org.bukkit.event.block.BlockIgniteEvent.IgniteCause;
 
-public class DenyFireSpreadEvent implements Listener {
+public class DenyFireSpreadListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void disableFireSpread(BlockIgniteEvent e) {

--- a/src/main/java/net/savagellc/savagecore/listener/DenyIPPostListener.java
+++ b/src/main/java/net/savagellc/savagecore/listener/DenyIPPostListener.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events;
+package net.savagellc.savagecore.listener;
 
 import net.savagellc.savagecore.persist.enums.Messages;
 import org.bukkit.event.EventHandler;
@@ -7,7 +7,7 @@ import org.bukkit.event.player.AsyncPlayerChatEvent;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class DenyIPPostEvent implements Listener {
+public class DenyIPPostListener implements Listener {
 
     @EventHandler
     public void onIPPost(AsyncPlayerChatEvent event) {

--- a/src/main/java/net/savagellc/savagecore/listener/DenyIceMeltListener.java
+++ b/src/main/java/net/savagellc/savagecore/listener/DenyIceMeltListener.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events;
+package net.savagellc.savagecore.listener;
 
 import net.savagellc.savagecore.persist.Conf;
 import org.bukkit.event.EventHandler;
@@ -7,7 +7,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockFadeEvent;
 import net.prosavage.baseplugin.XMaterial;
 
-public class DenyIceMeltEvent implements Listener {
+public class DenyIceMeltListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void iceMelt(BlockFadeEvent e) {

--- a/src/main/java/net/savagellc/savagecore/listener/DenyItemBurnListener.java
+++ b/src/main/java/net/savagellc/savagecore/listener/DenyItemBurnListener.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events;
+package net.savagellc.savagecore.listener;
 
 import net.savagellc.savagecore.persist.Conf;
 import org.bukkit.entity.Entity;
@@ -8,7 +8,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
-public class DenyItemBurnEvent implements Listener {
+public class DenyItemBurnListener implements Listener {
 
     @EventHandler
     public void onItemBurn(EntityDamageEvent e) {

--- a/src/main/java/net/savagellc/savagecore/listener/DenyPearlGlitchListener.java
+++ b/src/main/java/net/savagellc/savagecore/listener/DenyPearlGlitchListener.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events;
+package net.savagellc.savagecore.listener;
 
 import net.savagellc.savagecore.persist.Conf;
 import org.bukkit.Location;
@@ -10,7 +10,7 @@ import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.inventory.ItemStack;
 import java.util.Objects;
 
-public class DenyPearlGlitchEvent implements Listener {
+public class DenyPearlGlitchListener implements Listener {
 
     @EventHandler
     public void onPearlTeleport(PlayerTeleportEvent event) {

--- a/src/main/java/net/savagellc/savagecore/listener/DenySpawnerGuard.java
+++ b/src/main/java/net/savagellc/savagecore/listener/DenySpawnerGuard.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events;
+package net.savagellc.savagecore.listener;
 
 import net.savagellc.savagecore.persist.Conf;
 import net.savagellc.savagecore.persist.enums.Messages;

--- a/src/main/java/net/savagellc/savagecore/listener/DenySpawnerStorage.java
+++ b/src/main/java/net/savagellc/savagecore/listener/DenySpawnerStorage.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events;
+package net.savagellc.savagecore.listener;
 
 import net.savagellc.savagecore.persist.Conf;
 import net.savagellc.savagecore.persist.enums.Messages;

--- a/src/main/java/net/savagellc/savagecore/listener/DenyWaterRedstone.java
+++ b/src/main/java/net/savagellc/savagecore/listener/DenyWaterRedstone.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events;
+package net.savagellc.savagecore.listener;
 
 import net.savagellc.savagecore.persist.Conf;
 import org.bukkit.event.EventHandler;

--- a/src/main/java/net/savagellc/savagecore/listener/DenyWeatherListener.java
+++ b/src/main/java/net/savagellc/savagecore/listener/DenyWeatherListener.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events;
+package net.savagellc.savagecore.listener;
 
 import net.savagellc.savagecore.persist.Conf;
 import org.bukkit.event.EventHandler;
@@ -6,7 +6,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.weather.WeatherChangeEvent;
 
-public class DenyWeatherEvent implements Listener {
+public class DenyWeatherListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onWeatherChange(WeatherChangeEvent e) {

--- a/src/main/java/net/savagellc/savagecore/listener/FastIceBreakListener.java
+++ b/src/main/java/net/savagellc/savagecore/listener/FastIceBreakListener.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events;
+package net.savagellc.savagecore.listener;
 
 import com.massivecraft.factions.listeners.FactionsPlayerListener;
 import net.savagellc.savagecore.persist.Conf;
@@ -7,7 +7,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockDamageEvent;
 
-public class FastIceBreakEvent implements Listener {
+public class FastIceBreakListener implements Listener {
 
     @EventHandler
     public void onIceHit(BlockDamageEvent event) {

--- a/src/main/java/net/savagellc/savagecore/listener/autorespawn/AutoRespawnListener.java
+++ b/src/main/java/net/savagellc/savagecore/listener/autorespawn/AutoRespawnListener.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events.autorespawn;
+package net.savagellc.savagecore.listener.autorespawn;
 
 import net.savagellc.savagecore.persist.Conf;
 import org.bukkit.Bukkit;
@@ -10,14 +10,14 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.scheduler.BukkitRunnable;
 import java.util.Objects;
 
-public class AutoRespawnEvent implements Listener {
+public class AutoRespawnListener implements Listener {
 
     @EventHandler
     public void onPlayerDeath(PlayerDeathEvent e) {
         if (Conf.respawnScreenToggle) {
                 Location dl = e.getEntity().getLocation();
                 Player p = e.getEntity();
-                PreAutoRespawnEvent pre = new PreAutoRespawnEvent(p, dl);
+                PreAutoRespawnListener pre = new PreAutoRespawnListener(p, dl);
 
                 Bukkit.getPluginManager().callEvent(pre);
 
@@ -30,7 +30,7 @@ public class AutoRespawnEvent implements Listener {
                     public void run() {
                         p.spigot().respawn();
                         Location rl = e.getEntity().getLocation();
-                        Bukkit.getPluginManager().callEvent(new TargetAutoRespawnEvent(e.getEntity(), dl, rl));
+                        Bukkit.getPluginManager().callEvent(new TargetAutoRespawnListener(e.getEntity(), dl, rl));
                     }
                 }).runTaskTimer((Objects.requireNonNull(Bukkit.getPluginManager().getPlugin("SavageCore"))), 1L, 1L);
             }

--- a/src/main/java/net/savagellc/savagecore/listener/autorespawn/PreAutoRespawnListener.java
+++ b/src/main/java/net/savagellc/savagecore/listener/autorespawn/PreAutoRespawnListener.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events.autorespawn;
+package net.savagellc.savagecore.listener.autorespawn;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -9,7 +9,7 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.entity.EntityDamageEvent;
 import java.util.Objects;
 
-public class PreAutoRespawnEvent extends Event implements Cancellable {
+public class PreAutoRespawnListener extends Event implements Cancellable {
     private Player p;
     private Location dl;
     private boolean cl;
@@ -19,7 +19,7 @@ public class PreAutoRespawnEvent extends Event implements Cancellable {
         handlers = new HandlerList();
     }
 
-    PreAutoRespawnEvent(Player p, Location dl) {
+    PreAutoRespawnListener(Player p, Location dl) {
         this.cl = false;
         this.p = p;
         this.dl = dl;
@@ -46,11 +46,11 @@ public class PreAutoRespawnEvent extends Event implements Cancellable {
     }
 
     public HandlerList getHandlers() {
-        return PreAutoRespawnEvent.handlers;
+        return PreAutoRespawnListener.handlers;
     }
 
     public static HandlerList getHL() {
-        return PreAutoRespawnEvent.handlers;
+        return PreAutoRespawnListener.handlers;
     }
 
     public boolean isCancelled() {

--- a/src/main/java/net/savagellc/savagecore/listener/autorespawn/TargetAutoRespawnListener.java
+++ b/src/main/java/net/savagellc/savagecore/listener/autorespawn/TargetAutoRespawnListener.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events.autorespawn;
+package net.savagellc.savagecore.listener.autorespawn;
 
 import org.bukkit.event.Event;
 import org.bukkit.Location;
@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.entity.EntityDamageEvent;
 import java.util.Objects;
 
-public class TargetAutoRespawnEvent extends Event {
+public class TargetAutoRespawnListener extends Event {
     private Player p;
     private Location dl;
     private Location rl;
@@ -18,7 +18,7 @@ public class TargetAutoRespawnEvent extends Event {
         handlers = new HandlerList();
     }
 
-    TargetAutoRespawnEvent(Player p, Location dl, Location rl) {
+    TargetAutoRespawnListener(Player p, Location dl, Location rl) {
         this.p = p;
         this.rl = rl;
         this.dl = dl;
@@ -56,10 +56,10 @@ public class TargetAutoRespawnEvent extends Event {
     }
 
     public HandlerList getHandlers() {
-        return TargetAutoRespawnEvent.handlers;
+        return TargetAutoRespawnListener.handlers;
     }
 
     public static HandlerList getHandlerList() {
-        return TargetAutoRespawnEvent.handlers;
+        return TargetAutoRespawnListener.handlers;
     }
 }

--- a/src/main/java/net/savagellc/savagecore/listener/factions/AntiWildernessSpawner.java
+++ b/src/main/java/net/savagellc/savagecore/listener/factions/AntiWildernessSpawner.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events.factions;
+package net.savagellc.savagecore.listener.factions;
 
 import com.massivecraft.factions.Board;
 import com.massivecraft.factions.FLocation;

--- a/src/main/java/net/savagellc/savagecore/listener/mobs/FastIronGolemDeath.java
+++ b/src/main/java/net/savagellc/savagecore/listener/mobs/FastIronGolemDeath.java
@@ -1,10 +1,8 @@
-package net.savagellc.savagecore.events.mobs;
+package net.savagellc.savagecore.listener.mobs;
 
 import net.savagellc.savagecore.persist.Conf;
 import net.prosavage.baseplugin.XMaterial;
-import net.savagellc.savagecore.utils.FileManager;
 import org.bukkit.Material;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;

--- a/src/main/java/net/savagellc/savagecore/listener/player/BloodSprayListener.java
+++ b/src/main/java/net/savagellc/savagecore/listener/player/BloodSprayListener.java
@@ -1,4 +1,4 @@
-package net.savagellc.savagecore.events.player;
+package net.savagellc.savagecore.listener.player;
 
 import net.savagellc.savagecore.persist.Conf;
 import org.bukkit.Effect;
@@ -9,7 +9,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 
-public class BloodSprayEvent implements Listener {
+public class BloodSprayListener implements Listener {
 
     @EventHandler
     public void onPlayerHit(EntityDamageEvent e) {

--- a/src/main/java/net/savagellc/savagecore/persist/settings/FastIronGolemDeathSettings.java
+++ b/src/main/java/net/savagellc/savagecore/persist/settings/FastIronGolemDeathSettings.java
@@ -1,7 +1,5 @@
 package net.savagellc.savagecore.persist.settings;
 
-import net.savagellc.savagecore.events.mobs.FastIronGolemDeath;
-
 public class FastIronGolemDeathSettings {
 
     public boolean toggle;

--- a/target/classes/config.yml
+++ b/target/classes/config.yml
@@ -1,3 +1,0 @@
-fast-iron-golem-death:
-  toggle: true
-  damage: 20

--- a/target/classes/plugin.yml
+++ b/target/classes/plugin.yml
@@ -1,13 +1,13 @@
 name: SavageCore
 version: 1.4-STABLE
-main: me.ryder.savagecore.SavageCore
+main: net.savagellc.savagecore.SavageCore
 api-version: '1.13'
 authors: [Ryder]
 description: A plugin to improve the Factions experience.
 commands:
-  sc:
+  savagecore:
     aliases:
-      - savagecore
+      - score
     description: The base commands for SavageCore
 permissions:
   savagecore.reload:


### PR DESCRIPTION
**What type of PR is this?**  (Feature, Bug fix, Formatting etc.)
Formatting
**Link to relevant issue number(s), if any:**
N/A
**Explain your change(s):**
I changed all `event` to `listener` in all the classes as the `event` in classnames is misleading that the class is an event that will fire.
**Why did you make these change(s)?**
Code formatting :).
**Is there anything we need to know for compatability?** (variable names, placeholders etc.)
No there should not.